### PR TITLE
Make certificate optional in get/set keypair

### DIFF
--- a/lib/certificates/checkKeypair.js
+++ b/lib/certificates/checkKeypair.js
@@ -6,7 +6,7 @@ const fileNames = require("../fileNames");
 module.exports.checkKeypair = (opts, options) => {
     console.log("certificates.checkKeypair for", opts.subject);
 
-    let id = opts.certificate.kid || opts.certificate.id || opts.subject;
+    let id = (opts.certificate && (opts.certificate.kid || opts.certificate.id)) || opts.subject;
 
     let pemKeyPath = pathHelper.certificatesPath(options, id, fileNames.privkey.pem);
     // let jwkKeyPath = pathHelper.certificatesPath(options, id, fileNames.privkey.jwk);

--- a/lib/certificates/setKeypair.js
+++ b/lib/certificates/setKeypair.js
@@ -4,7 +4,7 @@ const pathHelper = require("../pathHelper");
 const fileNames = require("../fileNames");
 
 module.exports.setKeypair = (opts, options) => {
-    let id = opts.certificate.kid || opts.certificate.id || opts.subject;
+    let id = (opts.certificate && (opts.certificate.kid || opts.certificate.id)) || opts.subject;
     console.log("certificates.setKeypair for", id);
 
     let pemKeyPath = pathHelper.certificatesPath(options, id, fileNames.privkey.pem);


### PR DESCRIPTION
Hello,

Thanks for working on this project! It's been super helpful. I ran into an issue when registering a wildcard domain. It looks like `certificate` is not always defined on `opts`, which can lead to this error:

```
ERROR	TypeError: Cannot read property 'kid' of undefined
at Object.module.exports.checkKeypair (/var/task/node_modules/greenlock-storage-s3/lib/certificates/checkKeypair.js:9:31)
at Object.checkKeypair (/var/task/node_modules/greenlock-storage-s3/lib/certificates.js:8:59)
at /var/task/node_modules/greenlock/index.js:38:21
at process._tickCallback (internal/process/next_tick.js:68:7)
```

Looking around, I see that some [other Greenlock stores have had this issue as well](https://git.rootprojects.org/root/greenlock-store-sequelize.js/pulls/5). I created this pull request that basically copies what they did.

Please let me know if it's helpful or I can provide more info.

Thank you!