### PR TITLE
fix(accounts): Make check() be async

### DIFF
--- a/lib/accounts/check.js
+++ b/lib/accounts/check.js
@@ -1,6 +1,6 @@
 const pathHelper = require("../pathHelper");
 const fileNames = require("../fileNames");
 
-module.exports.check = (opts, options) => {
+module.exports.check = async (opts, options) => {
     console.log("accounts.check", opts.account.id);
 };


### PR DESCRIPTION
In greenlock@v3, `accounts.check` should return `Promise`.
ref: https://git.rootprojects.org/root/greenlock.js/src/branch/master/accounts.js#L199