### PR TITLE
Allow use of IAM instance profile credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ var greenlock = Greenlock.create({
 
 ```
 
+If using credentials from Environment variables, the shared credentials file, the ECS credentials provider (if applicable), or loaded from AWS IAM using the credentials provider of the Amazon EC2 instance (if configured in the instance metadata), omit the `accessKeyId` and `secretAccessKey`.
+
 ## Testing
 
 The strategy is tested against the [greenlock-store-test](https://git.coolaj86.com/coolaj86/greenlock-store-test.js)

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -1,12 +1,14 @@
 const AWS = require("aws-sdk");
 AWS.config.setPromisesDependency(Promise);
 
-module.exports = (options) => {
+module.exports = options => {
+  AWS.config.update({ region: options.bucketRegion });
+  if (options.accessKeyId != null && options.secretAccessKey != null) {
     AWS.config.update({
-        region: options.bucketRegion
-        , credentials: new AWS.Credentials({
-            accessKeyId: options.accessKeyId
-            , secretAccessKey: options.secretAccessKey
-        })
+      credentials: new AWS.Credentials({
+        accessKeyId: options.accessKeyId,
+        secretAccessKey: options.secretAccessKey
+      })
     });
-}
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "greenlock-storage-s3",
-  "version": "1.0.0",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenlock-storage-s3",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "S3 backed storage strategy for greenlock-express.js (and greenlock.js)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This storage strategy current supports setting IAM credentials via arguments, but does not support the use of credentials from environment variables, `.aws/credentials` files, or IAM instance profiles, all of which are supported by the underlying `aws-sdk`.  In our environment, all applications get their IAM credentials via instance profiles that we never have to set credentials in configuration.